### PR TITLE
make sure we pass both pin and state for writePin

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -123,7 +123,7 @@ app.post('/pin', async (req, res) => {
   }
   try {
     debug(`setPin request received for pin ${req.body.pin} and state ${parseInt(req.body.state)}`);
-    await firmata.setPin(req.body.pin);
+    await firmata.setPin(req.body.pin,req.body.state);
     return res.status(200).send("OK");
   } catch (error) {
     debug(error);


### PR DESCRIPTION
this fixes the writePin endpoint, but the readPin one still returns an error:

```
18.08.21 11:47:18 (+0200)  finblock    main getPin request received for pin 10 +1m
18.08.21 11:47:18 (+0200)  finblock    main TypeError [ERR_INVALID_ARG_TYPE]: The "listener" argument must be of type function. Received undefined
18.08.21 11:47:18 (+0200)  finblock    main     at checkListener (events.js:110:11)
18.08.21 11:47:18 (+0200)  finblock    main     at _addListener (events.js:347:3)
18.08.21 11:47:18 (+0200)  finblock    main     at Firmata.addListener (events.js:405:10)
18.08.21 11:47:18 (+0200)  finblock    main     at Firmata.digitalRead (/usr/src/app/node_modules/firmata-io/lib/firmata.js:1029:10)
18.08.21 11:47:18 (+0200)  finblock    main     at FirmataModule.getPin (/usr/src/app/utils/firmata/index.js:85:41)
18.08.21 11:47:18 (+0200)  finblock    main     at /usr/src/app/index.js:140:36
18.08.21 11:47:18 (+0200)  finblock    main     at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
18.08.21 11:47:18 (+0200)  finblock    main     at next (/usr/src/app/node_modules/express/lib/router/route.js:137:13)
18.08.21 11:47:18 (+0200)  finblock    main     at Route.dispatch (/usr/src/app/node_modules/express/lib/router/route.js:112:3)
18.08.21 11:47:18 (+0200)  finblock    main     at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
18.08.21 11:47:18 (+0200)  finblock    main     at /usr/src/app/node_modules/express/lib/router/index.js:281:22
18.08.21 11:47:18 (+0200)  finblock    main     at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)
18.08.21 11:47:18 (+0200)  finblock    main     at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)
18.08.21 11:47:18 (+0200)  finblock    main     at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:91:12)
18.08.21 11:47:18 (+0200)  finblock    main     at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)
18.08.21 11:47:18 (+0200)  finblock    main     at /usr/src/app/node_modules/express/lib/router/index.js:284:7
18.08.21 11:47:18 (+0200)  finblock    main     at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)
18.08.21 11:47:18 (+0200)  finblock    main     at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)
18.08.21 11:47:18 (+0200)  finblock    main     at /usr/src/app/index.js:37:3
18.08.21 11:47:18 (+0200)  finblock    main     at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
18.08.21 11:47:18 (+0200)  finblock    main     at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)
18.08.21 11:47:18 (+0200)  finblock    main     at /usr/src/app/node_modules/express/lib/router/index.js:284:7 +8ms
```